### PR TITLE
Harmonize description representation

### DIFF
--- a/wpi/extensions/PageEditor/PageEditor.php
+++ b/wpi/extensions/PageEditor/PageEditor.php
@@ -75,7 +75,7 @@ class PageEditor {
 						$description->setAttribute("Source", COMMENT_WP_DESCRIPTION);
 						$root->insertBefore($description, $root->firstChild);
 					}
-					$description->nodeValue = $content;
+					$description->textcontent = $content;
 
 					//Save the new GPML
 					$gpml = $doc->saveXML();


### PR DESCRIPTION
Description was previously stored "raw" in the XML code, resulting in
plenty of disruption with certain special characters (#46). On the other
hand it is read in PathwayData::getWikiDescription() as some escaped
text string, causing problems with round-tripability.

This commit modifies the writing part to escape the text string; a write
to the "nodeValue" property now writes to "textcontent" instead. Doing
so makes the description storage more robust and internally consistent
with the reading part. Writing to "textcontent" requires PHP 5.6.1+.

Fix #46.